### PR TITLE
chore: reconfigure Dependabot to fetch submodule updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,12 @@ updates:
       timezone: "Asia/Kolkata"
     commit-message:
       prefix: "chore(deps): "
+
+  - package-ecosystem: gitsubmodule
+    directory: ./web
+    schedule:
+      interval: daily
+      time: "06:00"
+      timezone: Asia/Kolkata
+    commit-message:
+      prefix: "chore(blogs): "


### PR DESCRIPTION
## Description

This PR contents updates the Dependabot configurations to fetch the private submodule updates (containing latest blog post entries).

Fixes #512 