### PR TITLE
chore: add custom `ProsePre` component

### DIFF
--- a/website/components/content/ProsePre.vue
+++ b/website/components/content/ProsePre.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="code-wrapper">
+    <!-- Add filename header -->
+    <div v-if="props.filename" class="code-header">
+      {{ props.filename }}
+    </div>
+
+    <!-- Call the original template -->
+    <div class="code-body">
+      <pre :class="props.class"><slot /></pre>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ProsePreProps } from "~/types/components/ProsePre";
+
+const props = defineProps<ProsePreProps>();
+</script>
+
+<style scoped lang="scss">
+.code-wrapper {
+  border: 1px solid #333;
+  border-radius: 6px;
+  overflow: hidden;
+  background: #1c2c35;
+
+  pre code .line {
+    display: block;
+  }
+
+  .code-header {
+    background: #2a2a2a;
+    padding: 6px 10px;
+    font-size: 0.8rem;
+    font-family: monospace;
+    color: #ccc;
+    border-bottom: 1px solid #333;
+  }
+
+  .code-body {
+    padding: 1rem 0.8rem;
+  }
+}
+</style>

--- a/website/types/components/ProsePre.ts
+++ b/website/types/components/ProsePre.ts
@@ -1,0 +1,37 @@
+/**
+ * Props for the `ProsePre` component.
+ *
+ * This interface defines the metadata and configurations for rendering a
+ * pre-formatted code block inside MDC/Markdown content via the Nuxt Content
+ * module or some customised `ProsePre` component.
+ */
+export interface ProsePreProps {
+  /**
+   * The raw code content to be rendered which will render an empty block if
+   * omitted.
+   *
+   */
+  code?: string;
+
+  /** The language identifier used for syntax highligting using Shiki. If `null`
+   * or `undefined` then no syntax highlighting is applied.
+   */
+  language?: string | null;
+
+  /** Optional file name to display above the code block. If `null` then no file
+   * names are rendered above the code block.
+   */
+  filename?: string | null;
+
+  /** The list of line numbers to highlight in the code block. **/
+  highlights?: number[];
+
+  /**
+   * Metadata string extracted from the code fence for manipulating the
+   * rendering behaviour of the code blocks.
+   **/
+  meta?: string | null;
+
+  /** Additional CSS class names to apply to the container element. **/
+  class?: string | null;
+}


### PR DESCRIPTION
## Description

This PR adds a custom `ProsePre` component which is partially inspired from the `ProsePre` component provided in the [nuxt-content/mdc](https://github.com/nuxt-content/mdc/blob/main/src/runtime/components/prose/ProsePre.vue) package. The component is work-in-progress since it has not been implemented to its expected behaviour. Regardless, the current implementation will be a starting point to improve the component further.

Following are some future improvements to make to the component:

1. Add a "copy" button which shows on hover.
2. Add number lines on the left without losing the syntax highlighting of the code.
3. Provide custom logic to intelligently render a "shell" or a "console" code fence differently.
4. Add a logic to handle diff'ing source code.

### Screenshots / Gifs

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/bb02da2b-e6ac-4bb5-9757-13b54de58e6e" />